### PR TITLE
HP-2617: Fix enabling Fee extension

### DIFF
--- a/src/HeppyTool.php
+++ b/src/HeppyTool.php
@@ -102,7 +102,7 @@ class HeppyTool
         'fee07' => FeeExtension::class,
         'fee08' => FeeExtension::class,
         'fee09' => FeeExtension::class,
-        'fee10' => FeeExtension::class,
+        // 'fee10' => FeeExtension::class,
         'fee11' => FeeExtension::class,
         'fee21' => FeeExtension::class,
         'fee23' => FeeExtension::class,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled the use of the 'fee10' extension within the tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->