### PR TITLE
Add error for new error message from EPP server; fix extensions

### DIFF
--- a/src/HeppyTool.php
+++ b/src/HeppyTool.php
@@ -102,7 +102,7 @@ class HeppyTool
         'fee07' => FeeExtension::class,
         'fee08' => FeeExtension::class,
         'fee09' => FeeExtension::class,
-        'fee10' => FeeExtension::class,
+        // 'fee10' => FeeExtension::class,
         'fee11' => FeeExtension::class,
         'fee21' => FeeExtension::class,
         'fee23' => FeeExtension::class,

--- a/src/modules/DomainModule.php
+++ b/src/modules/DomainModule.php
@@ -19,6 +19,8 @@ class DomainModule extends AbstractModule
     const DOMAIN_STANDART = 'standard';
     const DOMAIN_PREMIUM = 'premium';
 
+    const DOMAIN_OBJECT_NOT_FOUND_USING_SEARCH_TERM = 'domain object not found using search term';
+
     const RENEW_DOMAIN_NOT_AVAILABLE_EXCEPTION = "Invalid command name; Renew Domain not available";
     const RENEW_DOMAIN_AUTORENEW_RENEWONCE_EXCEPTION = "Invalid attribute value; explicit renewals not allowed for this TLD; please set domain to AUTORENEW or RENEWONCE";
     const RENEW_DOMAIN_DOES_NOT_MATCH_EXPIRATION = 'Parameter value range error Does not match expiration';
@@ -111,6 +113,11 @@ class DomainModule extends AbstractModule
             if (strpos($e->getMessage(), "Domain {$row['domain']} does not exist") !== false) {
                 throw new Exception(self::OBJECT_DOES_NOT_EXIST);
             }
+
+            if (strpos($e->getMessage(), self::DOMAIN_OBJECT_NOT_FOUND_USING_SEARCH_TERM) !== false) {
+                throw new Exception(self::OBJECT_DOES_NOT_EXIST);
+            }
+
 
             if (strpos($e->getMessage(), self::AUTHORIZATION_ERROR) !== false) {
                 throw new Exception(self::AUTHORIZATION_ERROR);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Domain lookups that fail by search term now return a consistent “object does not exist” error, improving clarity and alignment with other not-found scenarios.
- Chores
  - Disabled the fee10 extension from loading; fee10-related functionality is no longer available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->